### PR TITLE
refactor(domain): replace User with PublicUser to hide sensitive data

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,8 @@ dependencies {
     implementation("io.ktor:ktor-server-netty:$ktor_version")
     //implementation("ch.qos.logback:logback-classic:$logback_version")
 
-    //implementation("com.github.ImAngelParraga:TennisTournamentLib:v0.0.2")
-    implementation(files("C:\\Users\\ranki\\IdeaProjects\\TennisTournamentLib\\build\\libs\\TennisTournamentLib-0.0.2.jar"))
+    implementation("com.github.ImAngelParraga:TennisTournamentLib:v0.0.2")
+    //implementation(files("C:\\Users\\ranki\\IdeaProjects\\TennisTournamentLib\\build\\libs\\TennisTournamentLib-0.0.2.jar"))
 
     implementation("org.jetbrains.exposed:exposed-core:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")

--- a/src/main/kotlin/bros/parraga/db/schema/ClubEntity.kt
+++ b/src/main/kotlin/bros/parraga/db/schema/ClubEntity.kt
@@ -1,6 +1,7 @@
 package bros.parraga.db.schema
 
 import bros.parraga.domain.Club
+import bros.parraga.domain.PublicUser
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
@@ -27,6 +28,6 @@ class ClubDAO(id: EntityID<Int>) : IntEntity(id) {
         name = name,
         phoneNumber = phoneNumber,
         address = address,
-        user = user.toDomain()
+        user = PublicUser(user.id.value, user.username)
     )
 }

--- a/src/main/kotlin/bros/parraga/db/schema/PlayerEntity.kt
+++ b/src/main/kotlin/bros/parraga/db/schema/PlayerEntity.kt
@@ -1,6 +1,7 @@
 package bros.parraga.db.schema
 
 import bros.parraga.domain.Player
+import bros.parraga.domain.PublicUser
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
@@ -25,6 +26,6 @@ class PlayerDAO(id: EntityID<Int>) : IntEntity(id) {
             id.value,
             name,
             external,
-            user?.toDomain()
+            user?.let { PublicUser(it.id.value, it.username) }
         )
 }

--- a/src/main/kotlin/bros/parraga/domain/Club.kt
+++ b/src/main/kotlin/bros/parraga/domain/Club.kt
@@ -8,5 +8,5 @@ data class Club(
     val name: String,
     val phoneNumber: String?,
     val address: String?,
-    val user: User
+    val user: PublicUser
 )

--- a/src/main/kotlin/bros/parraga/domain/Player.kt
+++ b/src/main/kotlin/bros/parraga/domain/Player.kt
@@ -7,5 +7,5 @@ data class Player(
     val id: Int,
     val name: String,
     val external: Boolean,
-    val user: User? = null
+    val user: PublicUser? = null
 )

--- a/src/main/kotlin/bros/parraga/domain/User.kt
+++ b/src/main/kotlin/bros/parraga/domain/User.kt
@@ -11,3 +11,9 @@ data class User(
     val createdAt: Instant?,
     val updatedAt: Instant?
 )
+
+@Serializable
+data class PublicUser(
+    val id: Int,
+    val username: String
+)

--- a/src/main/kotlin/bros/parraga/services/repositories/tournament/TournamentRepositoryImpl.kt
+++ b/src/main/kotlin/bros/parraga/services/repositories/tournament/TournamentRepositoryImpl.kt
@@ -37,8 +37,8 @@ class TournamentRepositoryImpl : TournamentRepository {
     }
 
     override suspend fun updateTournament(request: UpdateTournamentRequest): Tournament = dbQuery {
-        TournamentDAO.findByIdAndUpdate(request.id) {
-            it.apply {
+        TournamentDAO.findByIdAndUpdate(request.id) { tournamentDAO ->
+            tournamentDAO.apply {
                 request.name?.let { name = it }
                 request.description?.let { description = it }
                 request.surface?.let { surface = it }
@@ -130,7 +130,7 @@ class TournamentRepositoryImpl : TournamentRepository {
                 status = match.status.name
             }
 
-            fakeIdsToRealMatches.put(match.id, matchDao)
+            fakeIdsToRealMatches[match.id] = matchDao
 
             match.dependencies.forEach { dependency ->
                 MatchDependencyDAO.new {


### PR DESCRIPTION
- Introduced `PublicUser` DTO containing only id and username.
- Updated `Player` and `Club` domain models to use `PublicUser` instead of the full `User` entity.
- Adjusted `ClubDAO` and `PlayerDAO` mappers to populate the new DTO.

This prevents exposure of email addresses and internal timestamps in public API endpoints like GET /players.